### PR TITLE
Updated figlet.cson to use latest atom spec

### DIFF
--- a/keymaps/figlet.cson
+++ b/keymaps/figlet.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor':
+'.atom-text-editor':
   'ctrl-alt-f': 'figlet:convert'


### PR DESCRIPTION
.editor is now deprecated.