### PR TITLE
Fix issues with `getCommentStrings` for Atom 1.23+

### DIFF
--- a/lib/figlet.coffee
+++ b/lib/figlet.coffee
@@ -65,7 +65,11 @@ module.exports =
     # Then, for the remaining string, we'll check whether there's a comment
     # or not
     scope = editor.scopeDescriptorForBufferPosition([start.row, 0])
-    {commentStartString, commentEndString} = editor.languageMode.commentStartAndEndStringsForScope?(scope) ? editor.getCommentStrings(scope)
+    {commentStartString, commentEndString} = (
+        editor.languageMode.commentStartAndEndStringsForScope?(scope) ?
+        editor.getCommentStrings?(scope) ?
+        editor.getScopedSettingsDelegate().getCommentStrings(scope)
+    )
 
     if commentStartString?
       commentStartRegexString = escapeRegExp(commentStartString).replace(/(\s+)$/, '')


### PR DESCRIPTION
It now calls `editor.getScopedSettingsDelegate().getCommentStrings(scope)` if `getCommentStrings` doesn't exist. See: [hydrogen/pull/1093](https://github.com/nteract/hydrogen/pull/1093/files#diff-3e2fce8735e63ba9d764917e356179cc)

I continued to use the slightly more verbose `?` operator because it seemed slightly better than a short circuit assignment and wrapped it across multiple lines because the API seems to have changed a bunch.

I tested it in 1.23 and 1.21. Fixes #9