### PR TITLE
editor.getScopedSettingsDelegate removed Atom 1.24

### DIFF
--- a/lib/figlet.coffee
+++ b/lib/figlet.coffee
@@ -65,7 +65,15 @@ module.exports =
     # Then, for the remaining string, we'll check whether there's a comment
     # or not
     scope = editor.scopeDescriptorForBufferPosition([start.row, 0])
-    {commentStartString, commentEndString} = editor.languageMode.commentStartAndEndStringsForScope?(scope) ? editor.getCommentStrings(scope)
+    
+    {commentStartString, commentEndString} = (
+        editor.languageMode.commentStartAndEndStringsForScope?(scope) ?
+        editor.getCommentStrings?(scope) ?
+        editor.getScopedSettingsDelegate?().getCommentStrings(scope) ?
+        editor.tokenizedBuffer.commentStringsForPosition(
+          editor.getCursorBufferPosition()
+        );
+    )
 
     if commentStartString?
       commentStartRegexString = escapeRegExp(commentStartString).replace(/(\s+)$/, '')


### PR DESCRIPTION
Reference to #9  #10  #11 ...
Looks like editor.getScopedSettingsDelegate was removed in Atom 1.24